### PR TITLE
Update brand kit with new fonts and tagline

### DIFF
--- a/CHROME-WEB-STORE.md
+++ b/CHROME-WEB-STORE.md
@@ -14,7 +14,7 @@
 **Name:** Duly Noted
 
 **Summary (132 characters max):**
-Capture voice notes with real-time transcription. Send to GitHub Issues, Projects, or Notion. Never lose a great idea again.
+capture creativity
 
 **Description (full):**
 ```
@@ -136,7 +136,7 @@ You need to provide **at least 1** screenshot (max 5):
 
 **Small Promo Tile (440x280):**
 - Eye-catching graphic representing the extension
-- Include icon and tagline: "Voice to Text, Ideas to Action"
+- Include icon and tagline: "capture creativity"
 
 **Large Promo Tile (920x680):**
 - Showcase key features with visuals

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Duly Noted 🎤
 
-**Capture voice notes with real-time transcription. Send to GitHub Issues, GitHub Projects, or Notion. Never lose a great idea again.**
+**capture creativity**
 
 A Chrome extension that lets you quickly capture voice notes using Web Speech API for real-time transcription. Instantly send notes to your favorite productivity tools or save them locally.
 

--- a/src/sidepanel/sidepanel.css
+++ b/src/sidepanel/sidepanel.css
@@ -39,7 +39,8 @@
   --spacing-xl: 24px;
 
   /* Fonts */
-  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-family-title: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-size-xs: 12px;
   --font-size-sm: 14px;
   --font-size-base: 16px;
@@ -71,6 +72,11 @@ body {
   overflow-x: hidden;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-family-title);
+  font-weight: 700;
+}
+
 /* ============================================================================
    Layout
    ============================================================================ */
@@ -95,8 +101,9 @@ body {
 }
 
 .header-title {
+  font-family: var(--font-family-title);
   font-size: var(--font-size-lg);
-  font-weight: 600;
+  font-weight: 700;
   margin: 0;
 }
 

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Duly Noted</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Open+Sans:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="sidepanel.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
Updates the brand kit for Duly Noted as requested in issue #7.

## Changes
- Title font: **Poppins Bold** (font-weight: 700)
- Sub font: **Open Sans**
- Tagline: **"capture creativity"**

## Files Modified
- `src/sidepanel/sidepanel.html` - Added Google Fonts import
- `src/sidepanel/sidepanel.css` - Updated font families and heading styles
- `README.md` - Updated tagline
- `CHROME-WEB-STORE.md` - Updated taglines

Closes #7

----
Generated with [Claude Code](https://claude.ai/code)